### PR TITLE
Fix: Wrong values from characteristics notifications 

### DIFF
--- a/lib/Characteristic.js
+++ b/lib/Characteristic.js
@@ -13,7 +13,7 @@ class Characteristic extends EventEmitter {
         this.onPropertyChanged = (intf, props, opts) => {
             if (intf !== "org.bluez.GattCharacteristic1") return;
             if (!props.Value) return;
-            this.emit("notify", Buffer.from(props.Value).toString());
+            this.emit("notify", Buffer.from(props.Value).toString('binary'));
         }
     }
 


### PR DESCRIPTION
Forced to binary encoding instead of default (utf8)
Solves #15 
