### PR TITLE
Typo on the getDevice method

### DIFF
--- a/lib/Adapter.js
+++ b/lib/Adapter.js
@@ -1,9 +1,10 @@
 const DbusInterfaceBase = require("./DbusInterfaceBase");
+const Device = require("./Device");
 
 class Adapter extends DbusInterfaceBase {
 
     getDevice(address) {
-        return this._bluez.findInterfaceInstance(Deviec.INTERFACE_NAME, Device, this._interface.objectPath, (d) => d.Address === address);
+        return this._bluez.findInterfaceInstance(Device.INTERFACE_NAME, Device, this._interface.objectPath, (d) => d.Address === address);
     }
 
     /*


### PR DESCRIPTION
The getDevice method on Adapter.js has a typo and is missing an include that makes it impossible to use it. This PR corrects the typo and adds the require.