### PR TITLE
Update DbusInterfaceBase.js

### DIFF
--- a/lib/DbusInterfaceBase.js
+++ b/lib/DbusInterfaceBase.js
@@ -5,6 +5,7 @@ class DbusInterfaceBase extends EventEmitter {
         super();
         this._interface = interface_;
         this._bluez = bluez;
+        this._propertyInterface = null;
 
         // forward property change events
         const forwardPropertyChange = (iface, changed, invalidated) => {


### PR DESCRIPTION
To fix the issue of accumulating listeners. The issue of accumulating listeners occurs because the code does not remove the forwardPropertyChange listener from the property interface when the DbusInterfaceBase instance is destroyed or when the PropertiesChanged event is no longer needed.